### PR TITLE
Fix: areDeploymentsEqual fails if ArmParameters

### DIFF
--- a/src/services/armService.ts
+++ b/src/services/armService.ts
@@ -160,7 +160,7 @@ export class ArmService extends BaseService {
 
     const paramsNormalizer = (params: ArmParameters): ArmParameters => {
       const normalized = {};
-      const keys = Object.keys(params);
+      const keys = Object.keys(params || {});
       for (const key of keys) {
         const original = params[key];
         normalized[key] = {


### PR DESCRIPTION


<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

If ArmParameters is undefined it fails with `TypeError: Cannot convert undefined or null to object`. Had this happen to me locally and this fixed my deployments... I'm not that well versed in Typescript or anything with azure really, so if there's more to be done, I can't be the one doing it ;-)

## How did you implement it:

Default to an empty object instead of undefined 

## How can we verify it:

Sample serverless.yml app trough the [quickstart](https://serverless.com/framework/docs/providers/azure/guide/quick-start/). Trying to deploy once succeeded, but the second time failed.. Deleted the functions and could not get it to deploy again.

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [ ] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** NO  
**_Is it a breaking change?:_** NO
